### PR TITLE
Integrate barcode scanner

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,6 +83,19 @@ dependencies {
     compile 'com.couchbase.lite:couchbase-lite-android:1.0.4'
     compile "com.fasterxml.jackson.core:jackson-core:2.5.4"
     compile "com.fasterxml.jackson.core:jackson-databind:2.5.4"
+
+    ///// ZXing library dependencies /////
+
+    // Supports Android 4.0.3 and later (API level 15)
+    compile 'com.journeyapps:zxing-android-embedded:2.0.1@aar'
+    compile 'com.journeyapps:zxing-android-integration:2.0.1@aar'
+
+    // Version 3.0.x of zxing core contains some code that is not compatible on Android 2.2 and earlier.
+    // This mostly affects encoding, but you should test if you plan to support these versions.
+    // Older versions e.g. 2.2 may also work if you need support for older Android versions.
+    compile 'com.google.zxing:core:3.0.1'
+
+    ///// End of ZXing /////
 }
 
 def buildTime() {

--- a/app/src/main/java/hu/bme/simonyi/acstudio/analogchaosinventoryapp/ui/home/fragments/ScanFragment.java
+++ b/app/src/main/java/hu/bme/simonyi/acstudio/analogchaosinventoryapp/ui/home/fragments/ScanFragment.java
@@ -48,16 +48,24 @@ public class ScanFragment extends RoboFragment {
                 if (barcodeScanHelper.isZxingInstalled()) {
                     startActivityForResult(barcodeScanHelper.getBarcodeScanIntent(), REQUEST_BARCODE_SCAN);
                 } else {
-                    barcodeScanHelper.showPlaystore();
+                    startIntegratedBarcodeScanner();
                 }
             }
         });
     }
 
+    /**
+     * Starts the built-in ZXing barcode scanner activity.
+     */
+    private void startIntegratedBarcodeScanner()
+    {
+        IntentIntegrator.forSupportFragment(this).initiateScan();
+    }
+
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == REQUEST_BARCODE_SCAN) {
+        if (requestCode == REQUEST_BARCODE_SCAN || requestCode == IntentIntegrator.REQUEST_CODE) {
             barcodeScanHelper.processBarcodeScanResult(resultCode, data);
         }
     }


### PR DESCRIPTION
Added ZXing library to app dependencies, ScanFragment starts built-in scanner instead of Play Store when the standalone app is not available.

(p.s. this is my first fork-commit-pull request combo, sorry if it is not correct)
